### PR TITLE
fix(qq): 支持短剧横屏正片的视频分类识别

### DIFF
--- a/tmdb-import/extractors/qq.py
+++ b/tmdb-import/extractors/qq.py
@@ -37,7 +37,7 @@ def qq_extractor(url):
             for episodeData in videoData["results"]:
                 category_map = episodeData["fields"]["category_map"]
                 
-                if len(category_map) > 1 and category_map[1] == "正片":
+                if any(isinstance(item, str) and "正片" in item for item in category_map):
                     episode_number_raw = int(episodeData["fields"]["episode"])
                     vid = episodeData["fields"]["vid"]
                     


### PR DESCRIPTION
 将腾讯视频提取器的正片判断从固定索引匹配改为模糊匹配， 解决短剧类视频（如"横屏正片"）无法被识别的问题。