### PR TITLE
Fix overview field newlines in CSV export

### DIFF
--- a/tmdb-import/common.py
+++ b/tmdb-import/common.py
@@ -33,7 +33,9 @@ class Episode:
         self.csv_header = ["episode_number", "name", "air_date", "runtime", "overview", "backdrop"]
 
     def __iter__(self):
-        return iter([self.episode_number, self.name, self.air_date, self.runtime, self.overview, self.backdrop])
+        # Remove newlines from overview when writing to CSV
+        clean_overview = self.overview.replace('\n', ' ').replace('\r', ' ') if self.overview else self.overview
+        return iter([self.episode_number, self.name, self.air_date, self.runtime, clean_overview, self.backdrop])
 
 class Season():
     def __init__(self, season_number, name="", overview="", episodes={}, poster="", crew={}, guest_stars={}):


### PR DESCRIPTION
## Summary
This PR fixes formatting issues in the CSV export caused by newline characters in the `overview` field.

## Changes
- Modified the `Episode.__iter__()` method in `common.py` to strip newlines (`\n` and `\r`) from the overview field before writing to CSV
- Newlines are replaced with spaces to maintain readability

## Problem
When episode overviews contain line breaks, they cause formatting issues in the generated `import.csv` file, making it difficult to parse and process correctly in subsequent operations.

## Solution
The fix ensures that overview text is cleaned during the CSV export process by replacing all newline characters with spaces, maintaining a single-line format for each CSV row.