### PR TITLE
feat(iqiyi): support album page URL (a_ format)

### DIFF
--- a/tmdb-import/extractors/iqiyi.py
+++ b/tmdb-import/extractors/iqiyi.py
@@ -11,6 +11,8 @@ def iqiyi_extractor(url):
     webPage = open_url(url)
     if url.__contains__("iqiyi.com/lib/m_"):
         albumId = re.search(r'movlibalbumaid=\"(\d+)\"', str(webPage)).group(1)
+    elif re.search(r'iqiyi\.com/a_', url):
+        albumId = re.search(r'data-album-id="(\d+)"', str(webPage)).group(1)
     else:
         albumId = re.search(r'\"albumId\":(\d+),\"channelId', str(webPage)).group(1)
     logging.info(f"album_id: {albumId}")
@@ -40,7 +42,7 @@ def iqiyi_extractor(url):
             episode_runtime = str(int(duration[0]) * 60 + int(duration[1]))
         elif len(duration) == 2:
             episode_runtime = duration[0] 
-        episode_overview = episode["description"].strip().replace("。\n", "。\p").replace("！\n", "！\p").replace("？\n", "？\p").replace("…\n", "…\p").replace("”\n", "”\p").replace("\n", "").replace("\p", "\n")
+        episode_overview = episode["description"].strip().replace("\u3002\n", "\u3002\p").replace("\uff01\n", "\uff01\p").replace("\uff1f\n", "\uff1f\p").replace("\u2026\n", "\u2026\p").replace("\u201d\n", "\u201d\p").replace("\n", "").replace("\p", "\n")
         episode_backdrop = episode["imageUrl"]
 
         pixel = ("0", "0")


### PR DESCRIPTION
## 变更内容

爱奇艺提取器新增对专辑主页地址（`a_` 格式）的支持。

### 问题

之前仅支持单集地址（`v_` 格式），用户输入专辑主页地址（如 `https://www.iqiyi.com/a_243zixmfjjd.html`）时无法提取 `albumId`，因为该格式页面的 HTML 结构不同。

### 解决方案

专辑主页的 HTML 中直接包含 `data-album-id` 属性，无需跳转到集数页，直接用正则 `data-album-id="(\d+)"` 提取即可。

### URL 支持矩阵

| URL 格式 | 示例 | 状态 |
|---|---|---|
| `lib/m_` 片库 | `iqiyi.com/lib/m_xxx` | 已有 |
| `a_` 专辑主页 | `iqiyi.com/a_xxx` | **新增** |
| `v_` 单集页 | `iqiyi.com/v_xxx` | 已有 |