### PR TITLE
fix(youku): migrate video API from api.youku.com to openapi.youku.com/v2

### DIFF
--- a/tmdb-import/extractors/youku.py
+++ b/tmdb-import/extractors/youku.py
@@ -17,10 +17,12 @@ def youku_extractor(url):
         showID = show_param
     elif vid_param or "video?" in url:
         episodeID = vid_param or re.search(r'id_(.*?)\.html', url).group(1).rstrip("==")
-        videoData = json.loads(open_url(f"https://api.youku.com/videos/show.json?video_id={episodeID}&ext=show&client_id={client_id}&package=com.huawei.hwvplayer.youku"))
+        videoData = json.loads(open_url(f"https://openapi.youku.com/v2/videos/show.json?video_id={episodeID}&ext=show&client_id={client_id}&package=com.huawei.hwvplayer.youku"))
         showID = videoData.get("show", {}).get("id") or episodeID
     else:
-        showID = re.search(r'id_(.*?)\.html', url).group(1).rstrip("==")
+        episodeID = re.search(r'id_(.*?)\.html', url).group(1).rstrip("==")
+        videoData = json.loads(open_url(f"https://openapi.youku.com/v2/videos/show.json?video_id={episodeID}&ext=show&client_id={client_id}&package=com.huawei.hwvplayer.youku"))
+        showID = videoData.get("show", {}).get("id") or episodeID
     
     logging.info(f"show id: {showID}")
     show_data = json.loads(open_url(f"https://openapi.youku.com/v2/shows/show.json?show_id={showID}&client_id={client_id}&package=com.huawei.hwvplayer.youku"))
@@ -76,7 +78,7 @@ def youku_extractor(url):
         for episode in showData["videos"]:
             episodeID = episode["id"].strip("==")
             try:
-                videoData = json.loads(open_url(f"https://api.youku.com/videos/show.json?video_id={episodeID}&client_id={client_id}&package=com.huawei.hwvplayer.youku"))
+                videoData = json.loads(open_url(f"https://openapi.youku.com/v2/videos/show.json?video_id={episodeID}&client_id={client_id}&package=com.huawei.hwvplayer.youku"))
                 episode_name = episode.get("rc_title") or videoData["title"]
                 episode_air_date = videoData["published"].split(" ")[0]
                 episode_runtime = round(float(videoData["duration"]) / 60)


### PR DESCRIPTION
## Problem

`api.youku.com/videos/show.json` no longer returns the `show` object (which contains the series `id`). Plain video page URLs (without `?s=` query param) could no longer resolve the correct show ID, causing the extractor to fall back to using the video ID as the show ID and subsequently failing all subsequent API calls.

## Changes

- Replace all calls to `api.youku.com/videos/show.json` with `openapi.youku.com/v2/videos/show.json`
- Add `ext=show` to the query so the response includes the nested `show` object with the series ID
- For plain video URLs (e.g. `https://v.youku.com/v_show/id_XNjUyMTM3MTY0OA==.html`), now query the API to resolve the real show ID instead of using the video ID directly

## Testing

Verified with a plain URL (no `?s=` param):
```
python -m tmdb-import "https://v.youku.com/v_show/id_XNjUyMTM3MTY0OA==.html"
# show id: bbaf2557249a4f2a9447  ✓
```