### PR TITLE
fix(qq): preserve episode order in concurrent requests

### DIFF
--- a/tmdb-import/extractors/qq.py
+++ b/tmdb-import/extractors/qq.py
@@ -1,7 +1,7 @@
 import json
 import logging
 import re
-from concurrent.futures import ThreadPoolExecutor, as_completed
+from concurrent.futures import ThreadPoolExecutor
 from ..common import Episode, open_url
 
 # ex: https://v.qq.com/x/cover/mzc00200t0fg7k8/o0043eaefxx.html?ptag=douban.tv
@@ -119,11 +119,11 @@ def qq_extractor(url):
             }
     
     # 使用线程池并发请求，最多15个并发（测试显示安全且更快）
+    # 使用 map() 保持集数顺序
     with ThreadPoolExecutor(max_workers=15) as executor:
-        futures = [executor.submit(fetch_episode_detail, info) for info in episode_base_info]
+        results = executor.map(fetch_episode_detail, episode_base_info)
         
-        for future in as_completed(futures):
-            result = future.result()
+        for result in results:
             episodes[result["episode_number"]] = Episode(
                 result["episode_number"],
                 result["episode_name"],


### PR DESCRIPTION
## Issue
After implementing concurrent requests in #44, episodes were being returned in random order based on API response completion time rather than episode sequence.

## Root Cause
The code used `as_completed(futures)` which processes results as they finish, not in submission order. While `episode_number` was used as dictionary key, Python dict insertion order meant episodes were stored in completion order.

## Solution
Replace `as_completed()` with `executor.map()` which:
- ✅ Maintains input order in output (waits for results in sequence)
- ✅ Keeps same concurrent execution (still 15 parallel workers)  
- ✅ Simplifies code (removes unnecessary list comprehension and result extraction)

## Changes
- Changed from `submit() + as_completed()` to `map()`
- Removed unused `as_completed` import
- Added comment explaining order preservation

## Testing
Episodes now correctly maintain order: 1, 2, 3, ... regardless of which API calls finish first.

## Related
- Fixes ordering issue introduced in #44