### PR TITLE
fix(netflix): update selectors for new Netflix UI and fix runtime parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ Windows 11, Chrome/Chromium, Python 3, and Visual Studio Code.
 | [mgtv](https://www.mgtv.com) | &#10004; | x | &#10004; | &#10004; | x | zh-CN |
 | [mytvsuper](https://www.mytvsuper.com) | &#10004; | &#10004; | &#10004; | &#10004; | &#10004; | zh-TW |
 | [myvideo](https://www.myvideo.net.tw) | &#10004; |  &#10004; | x | x | &#10004; | zh-TW |
-| [netflix](https://www.netflix.com) | &#10004; | &#10004; | x | &#10004; | x | Follow site |
+| [netflix](https://www.netflix.com) | &#10004; | &#10004; | x | x | x | Follow site |
 | [nhk](https://www.nhk.or.jp) | &#10004; | &#10004; | &#10004; | x | &#10004; | ja-JP |
 | [paravi](https://paravi.jp) | &#10004; | &#10004; | x | &#10004; | &#10004; | ja-JP |
 | [primevideo](https://www.primevideo.com) | &#10004; | &#10004; | &#10004; | &#10004; | &#10004; | Follow site |

--- a/docs/README.zh-CN.md
+++ b/docs/README.zh-CN.md
@@ -145,7 +145,7 @@ Windows 11、Chrome/Chromium、Python 3 和 Visual Studio Code。
 | [mgtv](https://www.mgtv.com)       | &#10004; |    x     | &#10004; | &#10004; |    x     | zh-CN    |
 | [mytvsuper](https://www.mytvsuper.com)  | &#10004; | &#10004; | &#10004; | &#10004; | &#10004; | zh-TW    |
 | [myvideo](https://www.myvideo.net.tw)    | &#10004; | &#10004; |    x     |    x     | &#10004; | zh-TW    |
-| [netflix](https://www.netflix.com)    | &#10004; | &#10004; |    x     | &#10004; |    x     | 跟随网站 |
+| [netflix](https://www.netflix.com)    | &#10004; | &#10004; |    x     | x |    x     | 跟随网站 |
 | [nhk](https://www.nhk.or.jp)        | &#10004; | &#10004; | &#10004; |    x     | &#10004; | ja-JP    |
 | [paravi](https://paravi.jp)     | &#10004; | &#10004; |    x     | &#10004; | &#10004; | ja-JP    |
 | [primevideo](https://www.primevideo.com) | &#10004; | &#10004; | &#10004; | &#10004; | &#10004; | 跟随网站 |

--- a/tmdb-import/extractors/netflix.py
+++ b/tmdb-import/extractors/netflix.py
@@ -10,16 +10,23 @@ def netflix_extractor(url):
     page = ini_playwright_page()
     try:
         page.goto(url)
-        source_data = page.locator(".episode").all()
+        source_data = page.locator("li[data-uia='episode-card']").all()
         episodes = {}
         episode_number = 1
         for episode in source_data:
             episode_number = episode_number
-            episode_name = episode.locator(".episode-title").text_content()
-            episode_name = re.split('\.|。', episode_name, maxsplit=1)[1]
+            episode_name = episode.locator("p[data-uia='episode-title']").text_content()
+            episode_name = re.split(r'\.|。', episode_name, maxsplit=1)[1].strip()
             episode_air_date = ""
-            episode_runtime = ''.join(filter(str.isdigit, episode.locator(".episode-runtime").text_content()))
-            episode_overview = episode.locator(".epsiode-synopsis").get_attribute('innerText')
+            runtime_text = episode.locator("div:first-child span").last.text_content()
+            runtime_parts = re.findall(r'\d+', runtime_text)
+            if len(runtime_parts) >= 2:
+                episode_runtime = str(int(runtime_parts[0]) * 60 + int(runtime_parts[1]))
+            elif len(runtime_parts) == 1:
+                episode_runtime = runtime_parts[0]
+            else:
+                episode_runtime = ""
+            episode_overview = episode.locator("p:not([data-uia='episode-title'])").text_content()
             episode_backdrop = ""
             
             episodes[episode_number] = Episode(episode_number, episode_name, episode_air_date, episode_runtime, episode_overview, episode_backdrop)


### PR DESCRIPTION
- Update episode card selector to \li[data-uia='episode-card']\\n- Update episode title selector to \p[data-uia='episode-title']\\n- Fix runtime parsing to handle hours/minutes format\n- Update episode overview selector\n- Update docs to reflect air date not supported