### PR TITLE
fix(viu): update extractor to new api-gateway-global API

### DIFF
--- a/tmdb-import/extractors/viu.py
+++ b/tmdb-import/extractors/viu.py
@@ -4,31 +4,37 @@ import logging
 from ..common import Episode, open_url
 from datetime import datetime
 
-# language: zh-CN
-# backdrop: 860*484
-# Ex:"https://www.viu.com/ott/sg/zh-cn/vod/309897/"
+# language: zh
+# backdrop: 1920x1080
+# Ex:"https://www.viu.com/ott/sg/zh/vod/2635502/
 
 # 区域映射表
 AREA_ID_MAP = {
     'sg': 2,    # 新加坡
     'hk': 1,    # 香港
+    'th': 4,    # 泰国
+    'ph': 5,    # 菲律宾
 }
 
 # 语言映射表
 LANGUAGE_FLAG_ID_MAP = {
+    'zh': 2,     # 简体中文
     'zh-cn': 2,  # 简体中文
-    'zh': 1,  # 繁体中文(香港)
+    'zh-hk': 1,  # 繁体中文(香港)
+    'en': 3,     # 英文
+    'th': 4,     # 泰文
+    'id': 8,     # 印度尼西亚文
 }
 
 def viu_extractor(url):
     logging.info("viu_extractor is called")
-    
+
     urlData = urlparse(url)
     urlPath = urlData.path.strip('/')
-    
+
     # 解析 URL 路径: ott/{area}/{language}/vod/{product_id}
     path_parts = urlPath.split('/')
-    if len(path_parts) >= 4:
+    if len(path_parts) >= 5:
         area_code = path_parts[1]  # sg
         language_code = path_parts[2]  # zh-cn
         product_id = path_parts[4]
@@ -37,33 +43,47 @@ def viu_extractor(url):
         area_code = 'sg'
         language_code = 'zh-cn'
         product_id = urlPath.rsplit('/', 1)[-1]
-    
+
     # 获取对应的 ID
     area_id = AREA_ID_MAP.get(area_code.lower(), 2)  # 默认值 2 (新加坡)
     language_flag_id = LANGUAGE_FLAG_ID_MAP.get(language_code.lower(), 2)  # 默认值 2 (简体中文)
-    
+
     logging.debug(f"Parsed area_code: {area_code}, area_id: {area_id}")
     logging.debug(f"Parsed language_code: {language_code}, language_flag_id: {language_flag_id}")
-    
-    apiRequest = f"https://www.viu.com/ott/{area_code}/index.php?area_id={area_id}&language_flag_id={language_flag_id}&r=vod/ajax-detail&platform_flag_label=web&product_id={product_id}"
+
+    # 获取 series_id
+    apiRequest = (f"https://api-gateway-global.viu.com/api/mobile?platform_flag_label=web&area_id={area_id}&language_flag_id={language_flag_id}&r=%2Fproduct%2Flistall&product_id={product_id}")
+    logging.debug(f"API request url: {apiRequest}")
+    resp = json.loads(open_url(apiRequest))
+    products = resp.get('data', {}).get('product', [])
+    match = next((p for p in products if str(p.get('product_id')) == str(product_id)), None)
+    if not match:
+        raise RuntimeError(f"Viu: 未找到 product_id={product_id} 的剧集信息。")
+    series_id = match['series_id']
+
+    # 获取剧集列表
+    apiRequest = (f"https://api-gateway-global.viu.com/api/mobile?platform_flag_label=web&area_id={area_id}&language_flag_id={language_flag_id}&r=%2Fvod%2Fproduct-list&series_id={series_id}&size=1000&sort=asc")
     logging.debug(f"API request url: {apiRequest}")
     soureData = json.loads(open_url(apiRequest))
-    series = soureData["data"]["series"]
-    season_number = 1
-    season_name = series["name"]
-    season_overview = series["description"]
-    
+
     episodes = {}
-    for episode in series["product"][::-1]:
-        apiRequest = f"https://www.viu.com/ott/{area_code}/index.php?area_id={area_id}&language_flag_id={language_flag_id}&r=vod/ajax-detail&platform_flag_label=web&product_id={episode['product_id']}"
-        logging.debug(f"API request url: {apiRequest}")
-        soureData = json.loads(open_url(apiRequest))
-        current_product = soureData["data"]["current_product"]
-        episode_number = current_product["number"]
-        episode_name = current_product["synopsis"]
-        episode_air_date = datetime.fromtimestamp(int(current_product["schedule_start_time"])).date()
-        episode_runtime = round(int(current_product["time_duration"])/60)
-        episode_overview = current_product["description"]
-        episode_backdrop = current_product["cover_image_url"]
+    for episode in soureData.get('data', {}).get('product_list', []):
+        episode_number = episode.get('number')
+        if episode_number is None:
+            continue
+        episode_name = episode.get('synopsis', '')
+        episode_air_date = None
+        ts = episode.get('schedule_start_time')
+        if ts:
+            try:
+                episode_air_date = datetime.fromtimestamp(int(ts)).date()
+            except (ValueError, OSError):
+                pass
+        episode_runtime = None
+        dur = episode.get('time_duration')
+        if dur:
+            episode_runtime = round(int(dur) / 60)
+        episode_overview = episode.get('description', '')
+        episode_backdrop = episode.get('cover_image_url', '')
         episodes[episode_number] = Episode(episode_number, episode_name, episode_air_date, episode_runtime, episode_overview, episode_backdrop)
     return episodes


### PR DESCRIPTION
## Problem

The old Viu API endpoint (`www.viu.com/ott/{area}/index.php?r=vod/ajax-detail`) is completely broken and returns `{"data":{"is_follow":0}}` — no episode data at all.

The old approach also made one HTTP request **per episode**, which was slow.

## Solution

Switch to two calls on the new `api-gateway-global.viu.com/api/mobile` endpoint (no auth required):

1. `/product/listall?product_id=` — resolve `series_id` from the given `product_id`
2. `/vod/product-list?series_id=&size=1000&sort=asc` — fetch all episodes in a single request

## Changes

- `tmdb-import/extractors/viu.py`
  - Replace broken `index.php?r=vod/ajax-detail` calls with the two-step `api-gateway-global` API
  - Handle missing/optional fields gracefully (`schedule_start_time`, `time_duration`, etc.)
  - Expand `AREA_ID_MAP`: add `th` (4), `ph` (5)
  - Expand `LANGUAGE_FLAG_ID_MAP`: add `zh` (2), `zh-hk` (1), `en` (3), `th` (4), `id` (8)