### PR TITLE
Add BiliBili International (bilibili.tv) extractor

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ Windows 11, Chrome/Chromium, Python 3, and Visual Studio Code.
 | [apple](https://tv.apple.com) | &#10004; | &#10004; | &#10004; | &#10004; | &#10004; | zh-CN |
 | [asahi](https://tv-asahi.co.jp) | &#10004; | &#10004; | &#10004; | &#10004; | &#10004; | ja-JP |
 | [bilibili](https://www.bilibili.com) | &#10004; | x | &#10004; | &#10004; | &#10004; | zh-CN |
+| [biliintl](https://www.bilibili.tv) | &#10004; | x | x | &#10004; | &#10004; | Follow site |
 | [crunchyroll](https://www.crunchyroll.com) | &#10004; | &#10004; | &#10004; | &#10004; | &#10004; | Follow site |
 | [cctv](https://tv.cctv.com) | &#10004; | &#10004; | &#10004; | x | &#10004; | zh-CN |
 | [disney+](https://www.disneyplus.com) | &#10004; | &#10004; | &#10004; | &#10004; | &#10004; | zh-CN |

--- a/docs/README.zh-CN.md
+++ b/docs/README.zh-CN.md
@@ -132,6 +132,7 @@ Windows 11、Chrome/Chromium、Python 3 和 Visual Studio Code。
 | [apple](https://tv.apple.com)      | &#10004; | &#10004; | &#10004; | &#10004; | &#10004; | zh-CN    |
 | [asahi](https://tv-asahi.co.jp)      | &#10004; | &#10004; | &#10004; | &#10004; | &#10004; | ja-JP    |
 | [bilibili](https://www.bilibili.com)   | &#10004; |    x     | &#10004; | &#10004; | &#10004; | zh-CN    |
+| [bilibili.tv](https://www.bilibili.tv) | &#10004; |    x     |    x     | &#10004; | &#10004; | 跟随网站 |
 | [crunchyroll](https://www.crunchyroll.com)| &#10004; | &#10004; | &#10004; | &#10004; | &#10004; | 跟随网站 |
 | [cctv](https://tv.cctv.com)       | &#10004; | &#10004; | &#10004; |    x     | &#10004; | zh-CN    |
 | [disney+](https://www.disneyplus.com)    | &#10004; | &#10004; | &#10004; | &#10004; | &#10004; | zh-CN    |

--- a/tmdb-import/extractor.py
+++ b/tmdb-import/extractor.py
@@ -19,6 +19,9 @@ def extract_from_url(url, language="zh-CN"):
     elif domain.endswith(".bilibili.com"):
         from .extractors import bilibili
         episodes = bilibili.bilibili_extractor(url)
+    elif domain.endswith(".bilibili.tv"):
+        from .extractors import biliintl
+        episodes = biliintl.bilibili_tv_extractor(url)
     elif domain.endswith(".crunchyroll.com"):
         from .extractors import crunchyroll
         episodes = crunchyroll.crunchyroll_extractor(url)

--- a/tmdb-import/extractors/biliintl.py
+++ b/tmdb-import/extractors/biliintl.py
@@ -1,0 +1,47 @@
+import json
+import re
+from urllib.parse import urlparse
+import logging
+from ..common import Episode, open_url
+
+# ex: https://www.bilibili.tv/en/media/2070355
+def bilibili_tv_extractor(url):
+    logging.info("bilibili_tv_extractor is called")
+
+    urlData = urlparse(url)
+    urlPath = urlData.path.strip('/')
+
+    seasonID = urlPath.split('/')[-1]
+    apiRequest = f"https://api.bilibili.tv/intl/gateway/web/v2/ogv/play/season_info?season_id={seasonID}&platform=web"
+    logging.debug(f"API request url: {apiRequest}")
+    seasonData = json.loads(open_url(apiRequest))
+
+    season = seasonData["data"]["season"]
+    season_name = season["title"]
+    logging.info(f"name: {season_name}")
+    season_poster = season.get("vertical_cover", "")
+    logging.info(f"poster: {season_poster}")
+    season_backdrop = season.get("horizontal_cover", "")
+    logging.info(f"backdrop: {season_backdrop}")
+
+    apiRequest = f"https://api.bilibili.tv/intl/gateway/web/v2/ogv/play/episodes?season_id={seasonID}&platform=web"
+    logging.debug(f"API request url: {apiRequest}")
+    episodesData = json.loads(open_url(apiRequest))
+
+    episodes = {}
+    episode_number = 1
+    for section in episodesData["data"]["sections"]:
+        for episode in section["episodes"]:
+            long_title = episode.get("long_title_display", "")
+            short_title = episode.get("short_title_display", "")
+            episode_name = long_title if long_title else short_title
+            # Leave name empty if it's just a plain episode number like E1, E2, ...
+            if re.fullmatch(r'E\d+', episode_name):
+                episode_name = ""
+            publish_time = episode.get("publish_time", "")
+            episode_air_date = publish_time[:10] if publish_time else "null"
+            episode_backdrop = episode.get("cover", "")
+            episodes[episode_number] = Episode(episode_number, episode_name, episode_air_date, "", "", episode_backdrop)
+            episode_number += 1
+
+    return episodes


### PR DESCRIPTION
## Summary

Adds support for extracting episode data from BiliBili International (`www.bilibili.tv`).

### Implementation

- New extractor `tmdb-import/extractors/biliintl.py`
  - Parses the `season_id` from the URL (e.g. `https://www.bilibili.tv/en/media/2070355`)
  - Calls `api.bilibili.tv/intl/gateway/web/v2/ogv/play/season_info` to retrieve the season title, poster (`vertical_cover`), and backdrop (`horizontal_cover`)
  - Calls `api.bilibili.tv/intl/gateway/web/v2/ogv/play/episodes` to retrieve all episodes across all sections
  - Uses `long_title_display` as the episode name, falling back to `short_title_display`
  - Leaves the episode name empty when it is a plain episode number (e.g. `E1`, `E2`, ...)
  - Parses `publish_time` (ISO 8601) to a plain date string for `air_date`
  - Note: the bilibili.tv API does not expose episode duration, so `runtime` is left empty

- `tmdb-import/extractor.py`: added routing for `domain.endswith(".bilibili.tv")`
- `README.md` / `docs/README.zh-CN.md`: added `bilibili.tv` row to the Supported Sites table